### PR TITLE
Send the user's apikey over to the packager

### DIFF
--- a/ckanext/ckanpackager/controllers/packager.py
+++ b/ckanext/ckanpackager/controllers/packager.py
@@ -96,6 +96,12 @@ class CkanPackagerController(t.BaseController):
             'email': email
         }
 
+        # if there is a logged in user, send over their apikey so that the
+        # packager can access resources that require authentication (i.e. ones
+        # in private datasets)
+        if t.c.userobj and t.c.userobj.apikey:
+            request_params['key'] = t.c.userobj.apikey
+
         resource = t.get_action('resource_show')(None, {'id': resource_id})
         if resource.get('datastore_active', False):
             if resource.get('format', '').lower() == 'dwc':


### PR DESCRIPTION
This allows the packaging of private dataset resources.

Requires https://github.com/NaturalHistoryMuseum/ckanpackager/pull/31.
Closes https://github.com/NaturalHistoryMuseum/ckanext-nhm/issues/296.