### PR TITLE
Allow choice of tsv or csv download format

### DIFF
--- a/ckanext/ckanpackager/controllers/packager.py
+++ b/ckanext/ckanpackager/controllers/packager.py
@@ -93,7 +93,9 @@ class CkanPackagerController(t.BaseController):
         request_params = {
             'secret': config['secret'],
             'resource_id': resource_id,
-            'email': email
+            'email': email,
+            # default to csv format, this can be overridden in the params
+            'format': u'csv',
         }
 
         resource = t.get_action('resource_show')(None, {'id': resource_id})
@@ -103,7 +105,7 @@ class CkanPackagerController(t.BaseController):
             else:
                 packager_url += '/package_datastore'
             request_params['api_url'] = config['datastore_api'] + '/datastore_search'
-            for option in ['filters', 'q', 'limit', 'offset', 'resource_url', 'sort']:
+            for option in ['filters', 'q', 'limit', 'offset', 'resource_url', 'sort', 'format']:
                 if option in params:
                     if option == 'filters':
                         request_params['filters'] = json.dumps(self._parse_filters(params['filters']))

--- a/ckanext/ckanpackager/lib/helpers.py
+++ b/ckanext/ckanpackager/lib/helpers.py
@@ -1,0 +1,12 @@
+from ckan.logic import get_action
+
+
+def should_show_format_options(resource_id):
+    """
+    Determines whether the format options should be shown for a given resource id.
+    :param resource_id: the resource's id
+    :return: True if they should be shown, False if not
+    """
+    resource = get_action('resource_show')({}, dict(id=resource_id))
+    # currently we just predicate on whether the resource is in the datastore or not
+    return resource.get('datastore_active', False)

--- a/ckanext/ckanpackager/plugin.py
+++ b/ckanext/ckanpackager/plugin.py
@@ -1,11 +1,12 @@
 import ckan.plugins as p
+from ckanext.ckanpackager.lib.helpers import should_show_format_options
 from ckanext.ckanpackager.lib.utils import url_for_package_resource
 
 config = {}
 
 
 class CkanPackagerPlugin(p.SingletonPlugin):
-    p.implements(p.interfaces.ITemplateHelpers)
+    p.implements(p.interfaces.ITemplateHelpers, inherit=True)
     p.implements(p.interfaces.IRoutes, inherit=True)
     p.implements(p.IConfigurable)
     p.implements(p.IConfigurer)
@@ -27,7 +28,8 @@ class CkanPackagerPlugin(p.SingletonPlugin):
         Provide a helper for create a download url from a resource id
         """
         return {
-            'url_for_package_resource': url_for_package_resource
+            'url_for_package_resource': url_for_package_resource,
+            'should_show_format_options': should_show_format_options
         }
 
     def before_map(self, map_route):

--- a/ckanext/ckanpackager/theme/public/css/ckanpackager.css
+++ b/ckanext/ckanpackager/theme/public/css/ckanpackager.css
@@ -22,12 +22,14 @@ div.ckanpackager-form input {
 div.ckanpackager-form div.options {
     text-align: left;
     vertical-align: middle;
+    padding-bottom: 0;
 }
 
 div.ckanpackager-form div.options label {
     vertical-align:middle;
     font-weight: normal;
     display: inline-block;
+    margin-left: 8px;
 }
 
 div.ckanpackager-form div.options label:after {

--- a/ckanext/ckanpackager/theme/public/scripts/modules/ckanpackager-download-link.js
+++ b/ckanext/ckanpackager/theme/public/scripts/modules/ckanpackager-download-link.js
@@ -50,7 +50,8 @@ this.ckan.module('ckanpackager-download-link', function(jQuery, _) {
         self.options = {
             overlay_width: 350,
             overlay_padding: 8,
-            page_container: '#content'
+            page_container: '#content',
+            resource_id: module.options.resourceId
         };
 
         /**
@@ -61,7 +62,8 @@ this.ckan.module('ckanpackager-download-link', function(jQuery, _) {
             // disable the button for now, we'll enable it once we get the template from the server
             self.disableButton();
             // request the template from the server, this is async
-            self.sandbox.client.getTemplate('ckanpackager_form.html', self._onReceiveSnippet);
+            var template_options = {resource_id: self.options.resource_id};
+            self.sandbox.client.getTemplate('ckanpackager_form.html', template_options, self._onReceiveSnippet);
         };
 
         /**
@@ -256,9 +258,9 @@ this.ckan.module('ckanpackager-download-link', function(jQuery, _) {
             $('#ckanpackager_total_records').html(totalRecordsText);
             // if the total records text hasn't been updated, hide the options, otherwise show them
             if (totalRecordsText === '') {
-                self.$form.find('div.options').hide();
+                self.$form.find('div.limits').hide();
             } else {
-                self.$form.find('div.options').show();
+                self.$form.find('div.limits').show();
             }
 
             self.$form.find('div.options input').change(function() {
@@ -330,6 +332,12 @@ this.ckan.module('ckanpackager-download-link', function(jQuery, _) {
                     }
                 }
             }
+            if (self.$form.find('input[name=format]:checked').val() === 'tsv') {
+                self.link_parts['qs']['format'] = ['tsv'];
+            } else {
+                self.link_parts['qs']['format'] = ['csv'];
+            }
+
             var send_url = self.link_parts['path'];
             if (self.is_anon) {
                 self.link_parts['qs']['email'] = [encodeURIComponent($('input.ckanpackager-email', self.$form).val())];

--- a/ckanext/ckanpackager/theme/public/scripts/modules/ckanpackager-download-link.js
+++ b/ckanext/ckanpackager/theme/public/scripts/modules/ckanpackager-download-link.js
@@ -51,7 +51,8 @@ this.ckan.module('ckanpackager-download-link', function(jQuery, _) {
             overlay_width: 350,
             overlay_padding: 8,
             page_container: '#content',
-            resource_id: module.options.resourceId
+            resource_id: module.options.resourceId,
+            is_record: module.options.isRecord
         };
 
         /**
@@ -62,7 +63,7 @@ this.ckan.module('ckanpackager-download-link', function(jQuery, _) {
             // disable the button for now, we'll enable it once we get the template from the server
             self.disableButton();
             // request the template from the server, this is async
-            var template_options = {resource_id: self.options.resource_id};
+            var template_options = {resource_id: self.options.resource_id, is_record: self.options.is_record};
             self.sandbox.client.getTemplate('ckanpackager_form.html', template_options, self._onReceiveSnippet);
         };
 

--- a/ckanext/ckanpackager/theme/templates/ajax_snippets/ckanpackager_form.html
+++ b/ckanext/ckanpackager/theme/templates/ajax_snippets/ckanpackager_form.html
@@ -7,11 +7,20 @@
             <input class="ckanpackager-email" type="text" name="email" placeholder="{{ _('Please enter your email address') }}" value="" />
         {% endif %}
 
-        <div class="options">
-            {{ _('Download') }}:
+        <div class="options limits">
+            {{ _('Download') }}:<br />
             <label for="page"><input id="page" type="radio" name="content" value="page" checked="checked"/> {{ _('this page only') }}</label>
-            <label for="all"><input id="all" type="radio" name="content" value="all"/> {{ _('all') }} <span id="ckanpackager_total_records">?</span> {{ _('records') }}</label>
+            <label for="all"><input id="all" type="radio" name="content" value="all"/> {{ _('all') }} <span id="ckanpackager_total_records">?</span> {{ _('records') }}</label><br />
         </div>
+        {% if h.should_show_format_options(resource_id) %}
+        <div class="options">
+            <form>
+                {{ _('Format') }}:<br />
+                <label for="{{ resource_id }}-csv"><input id="{{ resource_id }}-csv" type="radio" name="format" value="csv" checked="checked"/> {{ _('CSV') }}</label>
+                <label for="{{ resource_id }}-tsv"><input id="{{ resource_id }}-tsv" type="radio" name="format" value="tsv"/> {{ _('TSV') }}</label><br />
+            </form>
+        </div>
+        {% endif %}
         {% block action_buttons %}
             <a class="ckanpackager-send btn btn-primary" href="#">{{ _('Send') }}</a>
             <a class="ckanpackager-cancel btn btn-warning" href="#">{{ _('Cancel') }}</a>

--- a/ckanext/ckanpackager/theme/templates/ajax_snippets/ckanpackager_form.html
+++ b/ckanext/ckanpackager/theme/templates/ajax_snippets/ckanpackager_form.html
@@ -1,9 +1,17 @@
 <div>
     <div class="ckanpackager-form">
         {% if c.userobj %}
-            <p>{{ _('The resource will be extracted, with current filters applied, and an email will be sent to your registered address shortly.') }}</p>
+            {% if is_record == 'true' %}
+                <p>{{ _('The record will be packaged and sent to the email address registered with your account.') }}</p>
+            {% else %}
+                <p>{{ _('The resource will be extracted, with current filters applied, and an email will be sent to your registered address shortly.') }}</p>
+            {% endif %}
         {% else %}
-            <p>{{ _('The resource will be extracted, with current filters applied, and an email will be sent to the given address shortly.') }}</p>
+            {% if is_record == 'true' %}
+                <p>{{ _('Please enter your email address below, and the record will be packaged and sent to you.') }}</p>
+            {% else %}
+                <p>{{ _('The resource will be extracted, with current filters applied, and an email will be sent to the given address shortly.') }}</p>
+            {% endif %}
             <input class="ckanpackager-email" type="text" name="email" placeholder="{{ _('Please enter your email address') }}" value="" />
         {% endif %}
 

--- a/ckanext/ckanpackager/theme/templates/ckanpackager/snippets/package_resource.html
+++ b/ckanext/ckanpackager/theme/templates/ckanpackager/snippets/package_resource.html
@@ -8,6 +8,6 @@
 {% resource 'ckanext-ckanpackager/main' %}
 
 <a data-module="ckanpackager-download-link" class="packager-link btn btn-primary" data-module-resource-id="{{ res.id }}"
-   href="{{ h.url_for_package_resource(pkg.id, res.id) }}">
+   data-module-is-record="false" href="{{ h.url_for_package_resource(pkg.id, res.id) }}">
   <i class="{{ bt_class }}"></i> {{ bt_text }}
 </a>

--- a/ckanext/ckanpackager/theme/templates/ckanpackager/snippets/package_resource.html
+++ b/ckanext/ckanpackager/theme/templates/ckanpackager/snippets/package_resource.html
@@ -7,7 +7,7 @@
 
 {% resource 'ckanext-ckanpackager/main' %}
 
-<a data-module="ckanpackager-download-link" class="packager-link btn btn-primary"
+<a data-module="ckanpackager-download-link" class="packager-link btn btn-primary" data-module-resource-id="{{ res.id }}"
    href="{{ h.url_for_package_resource(pkg.id, res.id) }}">
   <i class="{{ bt_class }}"></i> {{ bt_text }}
 </a>


### PR DESCRIPTION
This only applies to datastore resources and defaults to csv.

Closes: https://github.com/NaturalHistoryMuseum/ckanext-ckanpackager/issues/3