### PR TITLE
Include the q parameter in download requests

### DIFF
--- a/ckanext/ckanpackager/theme/public/scripts/modules/ckanpackager-download-link.js
+++ b/ckanext/ckanpackager/theme/public/scripts/modules/ckanpackager-download-link.js
@@ -333,6 +333,9 @@ this.ckan.module('ckanpackager-download-link', function(jQuery, _) {
             if (window_link_parts['qs']['filters']) {
                 self.link_parts['qs']['filters'] = window_link_parts['qs']['filters'];
             }
+            if (window_link_parts['qs']['q']) {
+                self.link_parts['qs']['q'] = window_link_parts['qs']['q'];
+            }
             // Add offset/limit/sort if needed
             delete self.link_parts['qs']['offset'];
             delete self.link_parts['qs']['limit'];


### PR DESCRIPTION
Not exactly sure when this started being a problem as the code hasn't changed recently. The most obvious point to assume it occurred was during the ckan upgrade as there were some changes made to the `filters` and `q` parameters in the search js libs.

Note that this issue only affected downloads using the q parameter, anything using filters were fine (i.e. typing something in the search box wouldn't go through to the download packager but clicking a facet in the interface would).