### PR TITLE
Add parameter to defaultdict constructor to avoid KeyError

### DIFF
--- a/ckanext/ckanpackager/lib/utils.py
+++ b/ckanext/ckanpackager/lib/utils.py
@@ -192,7 +192,7 @@ def parse_filters(filters):
     '''
     # TODO: is there a CKAN API for this? The format changed with recent versions of CKAN, should we
     #       check for version?
-    result = defaultdict()
+    result = defaultdict(list)
     for f in filters.split(u'|'):
         try:
             name, value = f.split(u':', 1)


### PR DESCRIPTION
Argh. This was a bad change in this commit: https://github.com/NaturalHistoryMuseum/ckanext-ckanpackager/pull/14/commits/0f7a113be7ae9aa482c64628e564bc57e3ca943d#diff-fdfeb5ca86cd56eecd83164f1e8f790bL163