### PR TITLE
Remove the anon functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Ckanpackager is a stand-alone service that can be instructed to fetch data on a 
 
 The extension provides an HTML snippet that can be used to replace the Download button on resources. The new button will:
 - Provide an overlay explaining the link will be sent later on;
-- If anonymous downloading is enabled, provide a form for users to enter the destination email address;
+- Provide a form for users to enter the destination email address;
 - On resource pages, the button will ensure that currently applied filters and searches are forwarded on to the ckanpackager service.
 
 This extension uses a database table in the CKAN database to store stats about packaging events.

--- a/ckanext/ckanpackager/lib/utils.py
+++ b/ckanext/ckanpackager/lib/utils.py
@@ -24,15 +24,13 @@ def is_downloadable_resource(resource_id):
     return resource.get(u'datastore_active', False) or resource.get(u'url', False)
 
 
-def url_for_package_resource(package_id, resource_id, anon=True, use_request=True,
-                             extra_filters=None):
+def url_for_package_resource(package_id, resource_id, use_request=True, extra_filters=None):
     '''
     Given a resource_id, return the URL for packaging that resource. Will return an empty URL if the
     resource exists but is not downloadable.
 
     :param package_id: the package id
     :param resource_id: the resource id
-    :param anon: if True, will add 'anon=1' to the query string *if* this is an anonymous request
     :param use_request: if True (default) include the filters of the current request
     :param extra_filters: extra filters (on top of those in the request URL) to add to the link
     :raises ckan.plugins.toolkit.ObjectNotFound: if the resource does not exist
@@ -61,8 +59,6 @@ def url_for_package_resource(package_id, resource_id, anon=True, use_request=Tru
     params[u'resource_id'] = resource_id
     params[u'package_id'] = package_id
     params[u'destination'] = toolkit.request.url
-    if anon and not toolkit.c.user:
-        params[u'anon'] = u'1'
 
     return toolkit.url_for(u'ckanpackager.package_resource', **params)
 
@@ -92,12 +88,6 @@ def validate_request(resource_id):
             raise PackagerControllerError.build(u'This resource cannot be downloaded')
     except toolkit.ObjectNotFound:
         raise PackagerControllerError.build(u'Resource not found')
-
-    # validate anonymous access and email parameters
-    if u'anon' in toolkit.request.params:
-        # TODO: what the jamboree is this (what does anonymous access have to do with javascript?)
-        raise PackagerControllerError.build(u'You must be logged on or have javascript enabled to'
-                                            u'use this functionality.')
 
     # check that we have an email address
     if u'email' not in toolkit.request.params and not toolkit.c.user:

--- a/ckanext/ckanpackager/theme/public/scripts/modules/ckanpackager-download-link.js
+++ b/ckanext/ckanpackager/theme/public/scripts/modules/ckanpackager-download-link.js
@@ -89,9 +89,6 @@ this.ckan.module('ckanpackager-download-link', function(jQuery, _) {
             self.el.on('click', function(e) {
                 // TODO: Bugfix, update links parts with the url of the clicked link
                 self.link_parts = parseurl($(this).attr('href'));
-                if (typeof(self.link_parts['qs']['anon']) !== 'undefined') {
-                    delete self.link_parts['qs']['anon'];
-                }
                 self._update_send_link();
                 self.display($(this));
                 e.stopPropagation();
@@ -119,11 +116,6 @@ this.ckan.module('ckanpackager-download-link', function(jQuery, _) {
             }
 
             self.link_parts = parseurl(url);
-            self.is_anon = (typeof(self.link_parts['qs']['anon']) !== 'undefined');
-
-            if (typeof(self.link_parts['qs']['anon']) !== 'undefined') {
-                delete self.link_parts['qs']['anon'];
-            }
 
             // Prepare object
             self.$form = self._make_form(html);
@@ -132,11 +124,9 @@ this.ckan.module('ckanpackager-download-link', function(jQuery, _) {
             self._update_send_link();
 
             // Update send action when email address is entered
-            if (self.is_anon) {
-                $('input.ckanpackager-email', self.$form).change(function() {
-                    self._update_send_link();
-                });
-            }
+            $('input.ckanpackager-email', self.$form).change(function() {
+                self._update_send_link();
+            });
 
             // enable the button
             self.enableButton();
@@ -356,9 +346,7 @@ this.ckan.module('ckanpackager-download-link', function(jQuery, _) {
             }
 
             var send_url = self.link_parts['path'];
-            if (self.is_anon) {
-                self.link_parts['qs']['email'] = [encodeURIComponent($('input.ckanpackager-email', self.$form).val())];
-            }
+            self.link_parts['qs']['email'] = [encodeURIComponent($('input.ckanpackager-email', self.$form).val())];
             var cat = [];
             for (var i in self.link_parts['qs']) {
                 for (var j in self.link_parts['qs'][i]) {


### PR DESCRIPTION
Primarily this change has been made to make something work that was changed in a previous commit - namely the email input box being shown even if the user is logged in. The anon feature causes this email to always be used and anything entered by the user is ignored (this is because the input change hooks aren't registered). To fix this I've removed the anon functionality completely as we don't use it and I'm not convinced it even properly works.
