### PR TITLE
Add support for XLSX downloads

### DIFF
--- a/ckanext/ckanpackager/lib/helpers.py
+++ b/ckanext/ckanpackager/lib/helpers.py
@@ -3,11 +3,12 @@
 #
 # This file is part of ckanext-ckanpackager
 # Created by the Natural History Museum in London, UK
+from typing import List
 
 from ckan.plugins import toolkit
 
 
-def should_show_format_options(resource_id):
+def get_format_options(resource_id: str) -> List[str]:
     '''
     Determines whether the format options should be shown for a given resource id.
 
@@ -15,5 +16,9 @@ def should_show_format_options(resource_id):
     :returns: True if they should be shown, False if not
     '''
     resource = toolkit.get_action('resource_show')({}, dict(id=resource_id))
-    # currently we just predicate on whether the resource is in the datastore or not
-    return resource.get('datastore_active', False)
+    formats = []
+    if resource.get('datastore_active', False):
+        formats.extend(['CSV', 'TSV'])
+        if resource.get('format', '').lower() != 'dwc':
+            formats.append('XLSX')
+    return formats

--- a/ckanext/ckanpackager/plugin.py
+++ b/ckanext/ckanpackager/plugin.py
@@ -7,7 +7,7 @@
 from ckan.plugins import SingletonPlugin, implements, interfaces, toolkit
 
 from ckanext.ckanpackager import routes, cli
-from ckanext.ckanpackager.lib.helpers import should_show_format_options
+from ckanext.ckanpackager.lib.helpers import get_format_options
 from ckanext.ckanpackager.lib.utils import url_for_package_resource
 from ckanext.ckanpackager.logic import action, auth
 
@@ -43,7 +43,7 @@ class CkanPackagerPlugin(SingletonPlugin):
     def get_helpers(self):
         return {
             'url_for_package_resource': url_for_package_resource,
-            'should_show_format_options': should_show_format_options
+            'get_format_options': get_format_options
         }
 
     # IConfigurer

--- a/ckanext/ckanpackager/theme/assets/scripts/modules/ckanpackager-download-link.js
+++ b/ckanext/ckanpackager/theme/assets/scripts/modules/ckanpackager-download-link.js
@@ -339,10 +339,10 @@ this.ckan.module('ckanpackager-download-link', function(jQuery, _) {
                     }
                 }
             }
-            if (self.$form.find('input[name=format]:checked').val() === 'tsv') {
-                self.link_parts['qs']['format'] = ['tsv'];
-            } else {
-                self.link_parts['qs']['format'] = ['csv'];
+
+            const format_option = self.$form.find('input[name=format]:checked');
+            if (format_option.length) {
+                self.link_parts['qs']['format'] = [format_option.val()];
             }
 
             var send_url = self.link_parts['path'];

--- a/ckanext/ckanpackager/theme/templates/ajax_snippets/ckanpackager_form.html
+++ b/ckanext/ckanpackager/theme/templates/ajax_snippets/ckanpackager_form.html
@@ -28,18 +28,18 @@
                     <br />
                 </div>
 
-                {% if h.should_show_format_options(resource_id) %}
+                {% set formats = h.get_format_options(resource_id) %}
+                {% if formats %}
                 <div class="options">
                     {{ _('Format') }}:<br />
-                    <label for="{{ resource_id }}-csv">
-                        <input id="{{ resource_id }}-csv" type="radio" name="format" value="csv"
-                               checked="checked"/>
-                        {{ _('CSV') }}
-                    </label>
-                    <label for="{{ resource_id }}-tsv">
-                        <input id="{{ resource_id }}-tsv" type="radio" name="format" value="tsv"/>
-                        {{ _('TSV') }}
-                    </label>
+                    {% for format in formats %}
+                        <label for="{{ resource_id }}-{{ format }}">
+                            <input id="{{ resource_id }}-{{ format }}" type="radio" name="format"
+                                   value="{{ format | lower}}"
+                                   {% if loop.first %}checked="checked" {% endif %}/>
+                            {{ format }}
+                        </label>
+                    {% endfor %}
                     <br />
                 </div>
                 {% endif %}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,7 @@ services:
       - .:/srv/app/src/ckanext-ckanpackager
 
   solr:
-    build:
-      context: https://github.com/okfn/docker-ckan.git#:solr
+    image: ckan/ckan-solr:2.9
     logging:
       driver: none
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,23 +1,29 @@
-from ckanext.ckanpackager.lib.helpers import should_show_format_options
+from ckanext.ckanpackager.lib.helpers import get_format_options
 from unittest.mock import patch, MagicMock
 
 
-class TestShouldShowFormatOptions(object):
+class TestGetFormatOptions:
 
-    def test_has_datastore_active(self):
+    def test_datastore_active(self):
         resource = dict(datastore_active=True)
         toolkit = MagicMock(get_action=MagicMock(return_value=MagicMock(return_value=resource)))
         with patch('ckanext.ckanpackager.lib.helpers.toolkit', toolkit):
-            assert should_show_format_options(MagicMock())
+            assert get_format_options(MagicMock()) == ['CSV', 'TSV', 'XLSX']
 
-    def test_should_show_format_options_no(self):
+    def test_datastore_active_dwc(self):
+        resource = dict(datastore_active=True, format='dwc')
+        toolkit = MagicMock(get_action=MagicMock(return_value=MagicMock(return_value=resource)))
+        with patch('ckanext.ckanpackager.lib.helpers.toolkit', toolkit):
+            assert get_format_options(MagicMock()) == ['CSV', 'TSV']
+
+    def test_datastore_inactive(self):
         resource = dict(datastore_active=False)
         toolkit = MagicMock(get_action=MagicMock(return_value=MagicMock(return_value=resource)))
         with patch('ckanext.ckanpackager.lib.helpers.toolkit', toolkit):
-            assert not should_show_format_options(MagicMock())
+            assert get_format_options(MagicMock()) == []
 
-    def test_should_show_format_options_missing(self):
+    def test_datastore_inactive_missing(self):
         resource = dict()
         toolkit = MagicMock(get_action=MagicMock(return_value=MagicMock(return_value=resource)))
         with patch('ckanext.ckanpackager.lib.helpers.toolkit', toolkit):
-            assert not should_show_format_options(MagicMock())
+            assert get_format_options(MagicMock()) == []


### PR DESCRIPTION
Closes https://github.com/NaturalHistoryMuseum/data-portal/issues/437

Doesn't work for DwC files or non-datastore resources.

Note that this change removes a helper and therefore should result in a major version change (sozz).

Requires https://github.com/NaturalHistoryMuseum/ckanpackager/pull/62.