### PR TITLE
Pass the user's api key when requesting downloads

### DIFF
--- a/ckanext/ckanpackager/lib/utils.py
+++ b/ckanext/ckanpackager/lib/utils.py
@@ -115,6 +115,11 @@ def prepare_packager_parameters(resource_id, params):
         'format': 'csv',
     }
 
+    # if there is a logged-in user, send over their apikey so that the packager can access resources
+    # that require authentication (i.e. ones in private datasets)
+    if toolkit.c.userobj and toolkit.c.userobj.apikey:
+        request_params['key'] = toolkit.c.userobj.apikey
+
     if resource.get('datastore_active', False):
         # dwc resources get special treatment
         if resource.get('format', '').lower() == 'dwc':


### PR DESCRIPTION
Supersedes https://github.com/NaturalHistoryMuseum/ckanpackager/pull/31.
Closes https://github.com/NaturalHistoryMuseum/ckanext-nhm/issues/296.
Requires https://github.com/NaturalHistoryMuseum/ckanpackager/pull/64.