### PR TITLE
Add base/main dependency to resolve ckan.module missing error

### DIFF
--- a/ckanext/ckanpackager/theme/assets/webassets.yml
+++ b/ckanext/ckanpackager/theme/assets/webassets.yml
@@ -1,6 +1,9 @@
 main-js:
   output: ckanext-ckanpackager/%(version)s_main.js
   filters: rjsmin
+  extra:
+    preload:
+      - base/main
   contents:
     - scripts/modules/ckanpackager-download-link.js
 


### PR DESCRIPTION
Part closes https://github.com/NaturalHistoryMuseum/ckanext-nhm/issues/537